### PR TITLE
Update to Student Branch w/o revert commit (#145)

### DIFF
--- a/AssemblyManager.cpp
+++ b/AssemblyManager.cpp
@@ -909,6 +909,8 @@ void Building_Gene::retryBuildOrderElement(const UnitType & ut)
 
 void Building_Gene::getInitialBuildOrder(string s) {
 
+	building_gene_.clear();
+
     initial_building_gene_ = s;
 
     std::stringstream ss(s);

--- a/GeneticHistoryManager.cpp
+++ b/GeneticHistoryManager.cpp
@@ -74,7 +74,7 @@ GeneticHistory::GeneticHistory(string file, Player_Model& friendly_player_model)
         "drone drone drone drone drone pool drone extract overlord drone ling ling ling hydra_den drone drone drone drone", //zerg_9pool to hydra one base.
         "drone drone drone drone drone pool drone extract overlord drone creep ling ling ling sunken hydra_den drone drone drone drone", //zerg_9pool to hydra one base. + 1 creep
 
-        "drone drone drone drone drone overlord drone drone drone hatch pool drone drone" // 12hatch-pool
+        "drone drone drone drone drone overlord drone drone drone hatch pool drone drone", // 12hatch-pool
         "drone drone drone drone drone overlord drone drone drone hatch pool drone drone creep", // 12hatch-pool + 1 creep
         "drone drone drone drone drone overlord drone drone drone hatch pool drone creep drone creep", // 12hatch-pool + 2 creep
 
@@ -84,7 +84,7 @@ GeneticHistory::GeneticHistory(string file, Player_Model& friendly_player_model)
 
         "drone drone drone drone overlord drone drone drone hatch pool drone extract drone drone drone drone drone drone hydra_den drone overlord drone drone drone muscular_augments hydra hydra hydra hydra hydra hydra hydra overlord hydra hydra hydra hydra hydra hatch extract", //zerg_2hatchhydra - speed. added an overlord.
         "drone drone drone drone overlord drone drone drone hatch pool drone extract drone creep drone drone drone sunken drone drone hydra_den drone overlord drone drone drone muscular_augments hydra hydra hydra hydra hydra hydra hydra overlord hydra hydra hydra hydra hydra hatch extract", //zerg_2hatchhydra - speed. added an overlord. + 1 creep
-        "drone drone drone drone overlord drone drone drone hatch pool drone extract drone creep drone drone drone sunken drone drone hydra_den drone overlord creep drone drone drone muscular_augments sunken hydra hydra hydra hydra hydra hydra hydra overlord hydra hydra hydra hydra hydra hatch extract", //zerg_2hatchhydra - speed. added an overlord. + 2 creep
+        "drone drone drone drone overlord drone drone drone hatch pool drone extract drone creep drone drone drone sunken drone drone hydra_den drone overlord creep drone drone drone muscular_augments sunken hydra hydra hydra hydra hydra hydra hydra overlord hydra hydra hydra hydra hydra hatch extract" //zerg_2hatchhydra - speed. added an overlord. + 2 creep
     };
 
     // General Zerg vs Terran builds for most sitatuions
@@ -102,7 +102,7 @@ GeneticHistory::GeneticHistory(string file, Player_Model& friendly_player_model)
         "drone drone drone drone drone overlord drone drone drone pool drone extract hatch ling ling ling speed creep", // 12-pool tenative + 1 creep.
 
         "drone drone drone drone drone pool drone extract overlord drone ling ling ling lair drone overlord drone hydra_den hydra hydra hydra hydra ling ling ling ling lurker_tech", //1 h lurker, tenative.
-        "drone drone drone drone drone pool drone extract overlord creep drone ling ling ling lair drone overlord drone hydra_den hydra hydra hydra hydra ling ling ling ling lurker_tech" //1 h lurker, tenative. + 1 creep
+        "drone drone drone drone drone pool drone extract overlord creep drone ling ling ling lair drone overlord drone hydra_den hydra hydra hydra hydra ling ling ling ling lurker_tech", //1 h lurker, tenative. + 1 creep
         "drone drone drone drone drone pool drone extract overlord creep drone ling ling ling sunken lair drone creep overlord drone hydra_den hydra hydra hydra hydra ling ling ling ling lurker_tech" //1 h lurker, tenative. + 2 creep
     };
 
@@ -114,7 +114,7 @@ GeneticHistory::GeneticHistory(string file, Player_Model& friendly_player_model)
         "drone drone drone drone drone pool drone extract overlord creep drone ling ling ling sunken speed drone lair", //1 base - 9 pool to fast spire w/ ling speed + 1 creep
 
         "drone drone drone drone drone pool drone extract overlord drone ling ling ling drone drone lair", //1 base - 9 pool to fast spire w/o ling speed
-        "drone drone drone drone drone pool drone extract overlord creep drone ling ling ling sunken drone lair", //1 base - 9 pool to fast spire w/o ling speed + 1 creep
+        "drone drone drone drone drone pool drone extract overlord creep drone ling ling ling sunken drone lair" //1 base - 9 pool to fast spire w/o ling speed + 1 creep
     };
 
     // General builds against a random race opponent
@@ -511,17 +511,6 @@ GeneticHistory::GeneticHistory(string file, Player_Model& friendly_player_model)
     //    break; // if we have an interior solution, let's use it, if not, we try again.
     //}
     //}
-
-
-// Setup cartridges and overwrite previous values for specific matchups
-    // Cartridges for Zerg vs Zerg
-    if (Broodwar->enemy()->getRace() == Races::Zerg) {
-        map<UnitType, int> unit_cart = { { UnitTypes::Zerg_Zergling , INT_MIN }, { UnitTypes::Zerg_Mutalisk, INT_MIN } };
-        map<UnitType, int> building_cart = { { UnitTypes::Zerg_Hatchery, INT_MIN } ,{ UnitTypes::Zerg_Lair, INT_MIN }, { UnitTypes::Zerg_Spawning_Pool, INT_MIN } , {UnitTypes::Zerg_Evolution_Chamber, INT_MIN}, { UnitTypes::Zerg_Spire, INT_MIN }, { UnitTypes::Zerg_Creep_Colony, INT_MIN }, { UnitTypes::Zerg_Sunken_Colony, INT_MIN }, { UnitTypes::Zerg_Spore_Colony, INT_MIN } };
-        map<UpgradeType, int> upgrade_cart = { { UpgradeTypes::Metabolic_Boost, INT_MIN }, { UpgradeTypes::Zerg_Flyer_Carapace, INT_MIN }, { UpgradeTypes::Zerg_Flyer_Attacks, INT_MIN } };
-        map<TechType, int> tech_cart = { };
-        friendly_player_model.setLockedOpeningValues(unit_cart, building_cart, upgrade_cart, tech_cart, build_order_);
-    }
 
 
     // Overwrite whatever you previously wanted if we're using "test mode".

--- a/PlayerModelManager.cpp
+++ b/PlayerModelManager.cpp
@@ -106,165 +106,165 @@ void Player_Model::evaluateWorkerCount() {
 
 void Player_Model::playerStock(Player_Model & enemy_player_model)
 {
-	enemy_player_model.units_.inventoryCopy[25] = static_cast<int>(enemy_player_model.spending_model_.worker_stock);
-	enemy_player_model.units_.inventoryCopy[26] = static_cast<int>(enemy_player_model.spending_model_.army_stock);
-	enemy_player_model.units_.inventoryCopy[27] = static_cast<int>(enemy_player_model.spending_model_.tech_stock);
+    enemy_player_model.units_.inventoryCopy[25] = static_cast<int>(enemy_player_model.spending_model_.worker_stock);
+    enemy_player_model.units_.inventoryCopy[26] = static_cast<int>(enemy_player_model.spending_model_.army_stock);
+    enemy_player_model.units_.inventoryCopy[27] = static_cast<int>(enemy_player_model.spending_model_.tech_stock);
 }
 
 
 void Player_Model::readPlayerLog(Player_Model & enemy_player_model) // Function that reads in previous game's data
 {
-	string data;
-	int index = 0;
-	int iteration = 0;
-	ifstream infile(".\\bwapi-data\\write\\" + Broodwar->enemy()->getName() + ".txt", ios_base::in);
+    string data;
+    int index = 0;
+    int iteration = 0;
+    ifstream infile(".\\bwapi-data\\write\\" + Broodwar->enemy()->getName() + ".txt", ios_base::in);
 
-	int minStockCounter[29];
-	int maxStockCounter[29];
-	int minTimeCounter[29];
-	int maxTimeCounter[29];
+    int minStockCounter[29];
+    int maxStockCounter[29];
+    int minTimeCounter[29];
+    int maxTimeCounter[29];
 
-	fill_n(minStockAverage, 29, 0);
-	fill_n(minTimeAverage, 29, 0);
-	fill_n(maxTimeAverage, 29, 0);
-	fill_n(maxStockAverage, 29, 0);
-	fill_n(minStockCounter, 29, 0);
-	fill_n(minTimeCounter, 29, 0);
-	fill_n(maxStockCounter, 29, 0);
-	fill_n(maxTimeCounter, 29, 0);
+    fill_n(minStockAverage, 29, 0);
+    fill_n(minTimeAverage, 29, 0);
+    fill_n(maxTimeAverage, 29, 0);
+    fill_n(maxStockAverage, 29, 0);
+    fill_n(minStockCounter, 29, 0);
+    fill_n(minTimeCounter, 29, 0);
+    fill_n(maxStockCounter, 29, 0);
+    fill_n(maxTimeCounter, 29, 0);
 
-	int numoflines = 0;
-	getline(infile, data); //Skip 1 line
+    int numoflines = 0;
+    getline(infile, data); //Skip 1 line
 
 
-	infile.clear();
-	infile.seekg(std::ios::beg); // Move the start position to the second line
+    infile.clear();
+    infile.seekg(std::ios::beg); // Move the start position to the second line
 
-	infile.ignore(std::numeric_limits<std::streamsize>::max(), '\n');//ignore first line
+    infile.ignore(std::numeric_limits<std::streamsize>::max(), '\n');//ignore first line
 
-	while (infile >> data) // Read in the data
-	{
+    while (infile >> data) // Read in the data
+    {
 
-		if (data == ",")
-			infile >> data;
+        if (data == ",")
+            infile >> data;
 
-		stringstream conversion(data);
-		conversion >> oldMinStock[index];
+        stringstream conversion(data);
+        conversion >> oldMinStock[index];
 
-		if (oldMinStock[index] != 0)
-		{
-			minStockAverage[index] += oldMinStock[index];
-			minStockCounter[index]++;
-		}
+        if (oldMinStock[index] != 0)
+        {
+            minStockAverage[index] += oldMinStock[index];
+            minStockCounter[index]++;
+        }
 
-		conversion.str(std::string());
-		conversion.clear();
-		infile >> data;
-		infile >> data;
-		stringstream conversion2(data);
-		conversion2 >> oldMinTime[index];
+        conversion.str(std::string());
+        conversion.clear();
+        infile >> data;
+        infile >> data;
+        stringstream conversion2(data);
+        conversion2 >> oldMinTime[index];
 
-		if (oldMinTime[index] != 0)
-		{
-			minTimeAverage[index] += oldMinTime[index];
-			minTimeCounter[index] = minTimeCounter[index] + 1;
-		}
+        if (oldMinTime[index] != 0)
+        {
+            minTimeAverage[index] += oldMinTime[index];
+            minTimeCounter[index] = minTimeCounter[index] + 1;
+        }
 
-		conversion2.str(std::string());
-		conversion2.clear();
-		infile >> data;
-		infile >> data;
-		stringstream conversion3(data);
-		conversion3 >> oldMaxStock[index];
-		conversion3.str(std::string());
-		conversion3.clear();
+        conversion2.str(std::string());
+        conversion2.clear();
+        infile >> data;
+        infile >> data;
+        stringstream conversion3(data);
+        conversion3 >> oldMaxStock[index];
+        conversion3.str(std::string());
+        conversion3.clear();
 
-		if (oldMaxStock[index] != 0)
-		{
-			maxStockAverage[index] += oldMaxStock[index];
-			maxStockCounter[index] = maxStockCounter[index] + 1;
-			cout << maxStockCounter[index] << endl;
-		}
-		infile >> data;
-		infile >> data;
-		stringstream conversion4(data);
-		conversion4 >> oldMaxTime[index];
-		conversion4.str(std::string());
-		conversion4.clear();
+        if (oldMaxStock[index] != 0)
+        {
+            maxStockAverage[index] += oldMaxStock[index];
+            maxStockCounter[index] = maxStockCounter[index] + 1;
+            cout << maxStockCounter[index] << endl;
+        }
+        infile >> data;
+        infile >> data;
+        stringstream conversion4(data);
+        conversion4 >> oldMaxTime[index];
+        conversion4.str(std::string());
+        conversion4.clear();
 
-		if (oldMaxTime[index] != 0)
-		{
-			maxTimeAverage[index] += oldMaxTime[index];
-			maxTimeCounter[index]++;
-		}
+        if (oldMaxTime[index] != 0)
+        {
+            maxTimeAverage[index] += oldMaxTime[index];
+            maxTimeCounter[index]++;
+        }
 
-		index++;
+        index++;
 
-		if (index == 29 && !infile.eof())
-			index = 0;
+        if (index == 29 && !infile.eof())
+            index = 0;
 
-		iteration++;
-	}
+        iteration++;
+    }
 
-	for (int i = 0; i < 29; i++)
-	{
-		if (minStockCounter[i] > 0)
-			minStockAverage[i] /= minStockCounter[i];
-		if (minTimeCounter[i] > 0)
-			minTimeAverage[i] /= minTimeCounter[i];
-		if (maxStockCounter[i] > 0)
-			maxStockAverage[i] /= maxStockCounter[i];
-		if (maxTimeCounter[i] > 0)
-			maxTimeAverage[i] /= maxTimeCounter[i];
-		cout << "avg is " << minStockAverage[i] << endl;
-	}
+    for (int i = 0; i < 29; i++)
+    {
+        if (minStockCounter[i] > 0)
+            minStockAverage[i] /= minStockCounter[i];
+        if (minTimeCounter[i] > 0)
+            minTimeAverage[i] /= minTimeCounter[i];
+        if (maxStockCounter[i] > 0)
+            maxStockAverage[i] /= maxStockCounter[i];
+        if (maxTimeCounter[i] > 0)
+            maxTimeAverage[i] /= maxTimeCounter[i];
+        cout << "avg is " << minStockAverage[i] << endl;
+    }
 
 }
 void Player_Model::writePlayerLog(Player_Model & enemy_player_model, bool gameComplete) { //Function that records a player's noticed inventory
 
-	//Initialize all unit inventories seen to -1
-	if (Broodwar->getFrameCount() == 1)
-		for (int i = 0; i < 29; i++)
-			enemy_player_model.minTime[i] = 0;
+    //Initialize all unit inventories seen to -1
+    if (Broodwar->getFrameCount() == 1)
+        for (int i = 0; i < 29; i++)
+            enemy_player_model.minTime[i] = 0;
 
-	for (int i = 0; i < 29; i++)
-	{
-		if (enemy_player_model.units_.inventoryCopy[i] > 0 && enemy_player_model.minTime[i] == 0)
-		{
-			enemy_player_model.minTime[i] = Broodwar->elapsedTime();
-			enemy_player_model.minStock[i] = enemy_player_model.units_.inventoryCopy[i];
-		}
-		if (enemy_player_model.units_.inventoryCopy[i] > enemy_player_model.maxStock[i])
-		{
-			enemy_player_model.maxStock[i] = enemy_player_model.units_.inventoryCopy[i];
-			enemy_player_model.maxTime[i] = Broodwar->elapsedTime();
-		}
-	}
+    for (int i = 0; i < 29; i++)
+    {
+        if (enemy_player_model.units_.inventoryCopy[i] > 0 && enemy_player_model.minTime[i] == 0)
+        {
+            enemy_player_model.minTime[i] = Broodwar->elapsedTime();
+            enemy_player_model.minStock[i] = enemy_player_model.units_.inventoryCopy[i];
+        }
+        if (enemy_player_model.units_.inventoryCopy[i] > enemy_player_model.maxStock[i])
+        {
+            enemy_player_model.maxStock[i] = enemy_player_model.units_.inventoryCopy[i];
+            enemy_player_model.maxTime[i] = Broodwar->elapsedTime();
+        }
+    }
 
-			//Write to file once at the end of the game
-			if (gameComplete)
-			{
-				ifstream inFile(".\\bwapi-data\\write\\" + Broodwar->enemy()->getName() + ".txt", ios_base::in);
-				if (!inFile)
-				{
-					ofstream enemyData;
-					enemyData.open(".\\bwapi-data\\write\\" + Broodwar->enemy()->getName() + ".txt", ios_base::app);
-					for (int i = 0; i < 29; i++)
-							enemyData << left << setw(30) << enemy_player_model.units_.unitInventoryLabel[i];
-					enemyData << endl;
-				}
-				ofstream earliestDate;
-				earliestDate.open(".\\bwapi-data\\write\\" + Broodwar->enemy()->getName() + ".txt", ios_base::app);
+            //Write to file once at the end of the game
+            if (gameComplete)
+            {
+                ifstream inFile(".\\bwapi-data\\write\\" + Broodwar->enemy()->getName() + ".txt", ios_base::in);
+                if (!inFile)
+                {
+                    ofstream enemyData;
+                    enemyData.open(".\\bwapi-data\\write\\" + Broodwar->enemy()->getName() + ".txt", ios_base::app);
+                    for (int i = 0; i < 29; i++)
+                            enemyData << left << setw(30) << enemy_player_model.units_.unitInventoryLabel[i];
+                    enemyData << endl;
+                }
+                ofstream earliestDate;
+                earliestDate.open(".\\bwapi-data\\write\\" + Broodwar->enemy()->getName() + ".txt", ios_base::app);
 
-				for (int i = 0; i < 29; i++)
-				{
-					stringstream ss;
-					ss << enemy_player_model.minStock[i] << " , " << enemy_player_model.minTime[i] << " , " << enemy_player_model.maxStock[i] << " , " << enemy_player_model.maxTime[i];
-					earliestDate << left << setw(30) << ss.str();
-				}
-				earliestDate << endl;
-				earliestDate.close();
-			}
+                for (int i = 0; i < 29; i++)
+                {
+                    stringstream ss;
+                    ss << enemy_player_model.minStock[i] << " , " << enemy_player_model.minTime[i] << " , " << enemy_player_model.maxStock[i] << " , " << enemy_player_model.maxTime[i];
+                    earliestDate << left << setw(30) << ss.str();
+                }
+                earliestDate << endl;
+                earliestDate.close();
+            }
 }
 void Player_Model::evaluateCurrentWorth()
 {
@@ -343,7 +343,7 @@ void Player_Model::updateUnit_Counts() {
 
 // sample command set to explore zergling rushing.
 void Player_Model::setLockedOpeningValuesLingRush() {
-     
+
     // sample command set to explore zergling rushing.
      spending_model_.alpha_army = CUNYAIModule::alpha_army_original = 0.90;
      spending_model_.alpha_econ = CUNYAIModule::alpha_econ_original = 0.10;
@@ -359,27 +359,29 @@ void Player_Model::setLockedOpeningValuesLingRush() {
     building_cartridge_ = { { UnitTypes::Zerg_Hatchery, INT_MIN }, { UnitTypes::Zerg_Spawning_Pool, INT_MIN } , {UnitTypes::Zerg_Evolution_Chamber, INT_MIN},{ UnitTypes::Zerg_Queens_Nest, INT_MIN },{ UnitTypes::Zerg_Lair, INT_MIN }, { UnitTypes::Zerg_Hive, INT_MIN } };
     upgrade_cartridge_ = { { UpgradeTypes::Zerg_Carapace, INT_MIN } ,{ UpgradeTypes::Zerg_Melee_Attacks, INT_MIN },{ UpgradeTypes::Pneumatized_Carapace, INT_MIN },{ UpgradeTypes::Metabolic_Boost, INT_MIN }, { UpgradeTypes::Adrenal_Glands, INT_MIN } };
     tech_cartridge_ = {  };
-    
+
 }
 
 // Generic command set for locked values
-// Must pass cartridges, every other parameter can be left to default (passing builds in is currently bugged)
-void Player_Model::setLockedOpeningValues(const map<UnitType, int>& unit_cart, const map<UnitType, int>& building_cart, const map<UpgradeType, int>& upgrade_cart, const map<TechType, int>& tech_cart, 
-                                          const string& build, const int& a_army, const int& a_econ, const int& a_tech, const int& delta, const int& gamma) {
+// Must pass cartridges and build, every other parameter can be left to default (values can not be set to 0 (set to 0.0001 instead).
+void Player_Model::setLockedOpeningValues(const map<UnitType, int>& unit_cart, const map<UnitType, int>& building_cart, const map<UpgradeType, int>& upgrade_cart, const map<TechType, int>& tech_cart,
+                                          const string& build, const double& a_army, const double& a_econ, const double& a_tech, const double& delta, const double& gamma, const double& r) {
 
     if (a_army)
-        spending_model_.alpha_army = CUNYAIModule::alpha_army_original = a_army;
+        spending_model_.alpha_army = CUNYAIModule::gene_history.a_army_out_mutate_ = CUNYAIModule::alpha_army_original = a_army;
     if (a_econ)
-        spending_model_.alpha_econ = CUNYAIModule::alpha_econ_original = a_econ;
+        spending_model_.alpha_econ = CUNYAIModule::gene_history.a_econ_out_mutate_ = CUNYAIModule::alpha_econ_original = a_econ;
     if (a_tech)
-        spending_model_.alpha_tech = CUNYAIModule::alpha_tech_original = a_tech;
+        spending_model_.alpha_tech = CUNYAIModule::gene_history.a_tech_out_mutate_ = CUNYAIModule::alpha_tech_original = a_tech;
 
     if (delta)
-        CUNYAIModule::delta = delta;
+        CUNYAIModule::gene_history.delta_out_mutate_ = CUNYAIModule::delta = delta;
     if (gamma)
-        CUNYAIModule::gamma = gamma;
+        CUNYAIModule::gene_history.gamma_out_mutate_ = CUNYAIModule::gamma = gamma;
+    if (r)
+        CUNYAIModule::gene_history.r_out_mutate_ = CUNYAIModule::adaptation_rate = r;
 
-    //CUNYAIModule::buildorder = Building_Gene(build);  Some sort of bug currently with this
+    CUNYAIModule::buildorder = Building_Gene(build);
 
     //unit cartridges (while these only are relevant for CUNYBot, they are still  passed to all players anyway by default on construction), Combat unit cartridge is all mobile noneconomic units we may consider building (excludes static defense).
     combat_unit_cartridge_ = unit_cart;
@@ -387,5 +389,4 @@ void Player_Model::setLockedOpeningValues(const map<UnitType, int>& unit_cart, c
     building_cartridge_ = building_cart;
     upgrade_cartridge_ = upgrade_cart;
     tech_cartridge_ = tech_cart;
-
 }

--- a/Source/CUNYAIModule.cpp
+++ b/Source/CUNYAIModule.cpp
@@ -54,102 +54,170 @@ ScoutingManager scouting;
 void CUNYAIModule::onStart()
 {
 	//foundDetector = false;
-    // Hello World!
-    Broodwar->sendText( "Good luck, have fun!" );
+	// Hello World!
+	Broodwar->sendText("Good luck, have fun!");
 
-    // Print the map name.
-    // BWAPI returns std::string when retrieving a string, don't forget to add .c_str() when printing!
-    Broodwar << "The map is " << Broodwar->mapName() << "!" << std::endl;
+	// Print the map name.
+	// BWAPI returns std::string when retrieving a string, don't forget to add .c_str() when printing!
+	Broodwar << "The map is " << Broodwar->mapName() << "!" << std::endl;
 
-    // Enable the UserInput flag, which allows us to control the bot and type messages. Also needed to get the screen position.
-    Broodwar->enableFlag( Flag::UserInput );
+	// Enable the UserInput flag, which allows us to control the bot and type messages. Also needed to get the screen position.
+	Broodwar->enableFlag(Flag::UserInput);
 
-    // Uncomment the following line and the bot will know about everything through the fog of war (cheat).
-    //Broodwar->enableFlag(Flag::CompleteMapInformation);
+	// Uncomment the following line and the bot will know about everything through the fog of war (cheat).
+	//Broodwar->enableFlag(Flag::CompleteMapInformation);
 
-    // Set the command optimization level so that common commands can be grouped
-    // and reduce the bot's APM (Actions Per Minute).
-    Broodwar->setCommandOptimizationLevel( 2 );
+	// Set the command optimization level so that common commands can be grouped
+	// and reduce the bot's APM (Actions Per Minute).
+	Broodwar->setCommandOptimizationLevel(2);
 
-    // Check if this is a replay
-    if ( Broodwar->isReplay() )
-    {
+	// Check if this is a replay
+	if (Broodwar->isReplay())
+	{
 
-        // Announce the players in the replay
-        Broodwar << "The following players are in this replay:" << std::endl;
+		// Announce the players in the replay
+		Broodwar << "The following players are in this replay:" << std::endl;
 
-        // Iterate all the players in the game using a std:: iterator
-        Playerset players = Broodwar->getPlayers();
-        for ( auto p : players )
-        {
-            // Only print the player if they are not an observer
-            if ( !p->isObserver() )
-                Broodwar << p->getName() << ", playing as " << p->getRace() << std::endl;
-        }
+		// Iterate all the players in the game using a std:: iterator
+		Playerset players = Broodwar->getPlayers();
+		for (auto p : players)
+		{
+			// Only print the player if they are not an observer
+			if (!p->isObserver())
+				Broodwar << p->getName() << ", playing as " << p->getRace() << std::endl;
+		}
 
-    }
-    else // if this is not a replay
-    {
-        // Retrieve you and your enemy's races. enemy() will just return the first enemy.
-        // If you wish to deal with multiple enemies then you must use enemies().
-        if ( Broodwar->enemy() ) // First make sure there is an enemy
-            Broodwar << "The matchup is " << Broodwar->self()->getRace() << " vs " << Broodwar->enemy()->getRace() << std::endl;
-    }
+	}
+	else // if this is not a replay
+	{
+		// Retrieve you and your enemy's races. enemy() will just return the first enemy.
+		// If you wish to deal with multiple enemies then you must use enemies().
+		if (Broodwar->enemy()) // First make sure there is an enemy
+			Broodwar << "The matchup is " << Broodwar->self()->getRace() << " vs " << Broodwar->enemy()->getRace() << std::endl;
+	}
 
-    //Initialize state variables
-    gas_starved = false;
-    army_starved = false;
-    supply_starved = false;
-    econ_starved = true;
-    tech_starved = false;
+	//Initialize state variables
+	gas_starved = false;
+	army_starved = false;
+	supply_starved = false;
+	econ_starved = true;
+	tech_starved = false;
 
-    //Initialize model variables.
+	//Initialize model variables.
+	gene_history = GeneticHistory(".\\bwapi-data\\read\\output.txt", friendly_player_model);
 
-    gene_history = GeneticHistory( ".\\bwapi-data\\read\\output.txt", friendly_player_model );
+	delta = gene_history.delta_out_mutate_; //gas starved parameter. Triggers state if: ln_gas/(ln_min + ln_gas) < delta;  Higher is more gas.
+	gamma = gene_history.gamma_out_mutate_; //supply starved parameter. Triggers state if: ln_supply_remain/ln_supply_total < gamma; Current best is 0.70. Some good indicators that this is reasonable: ln(4)/ln(9) is around 0.63, ln(3)/ln(9) is around 0.73, so we will build our first overlord at 7/9 supply. ln(18)/ln(100) is also around 0.63, so we will have a nice buffer for midgame.
 
+	//Cobb-Douglas Production exponents.  Can be normalized to sum to 1.
+	alpha_army_original = friendly_player_model.spending_model_.alpha_army = gene_history.a_army_out_mutate_; // army starved parameter.
+	alpha_econ_original = friendly_player_model.spending_model_.alpha_econ = gene_history.a_econ_out_mutate_; // econ starved parameter.
+	alpha_tech_original = friendly_player_model.spending_model_.alpha_tech = gene_history.a_tech_out_mutate_; // tech starved parameter.
+	adaptation_rate = gene_history.r_out_mutate_; //rate of worker growth.
 
-    delta = gene_history.delta_out_mutate_; //gas starved parameter. Triggers state if: ln_gas/(ln_min + ln_gas) < delta;  Higher is more gas.
-    gamma = gene_history.gamma_out_mutate_; //supply starved parameter. Triggers state if: ln_supply_remain/ln_supply_total < gamma; Current best is 0.70. Some good indicators that this is reasonable: ln(4)/ln(9) is around 0.63, ln(3)/ln(9) is around 0.73, so we will build our first overlord at 7/9 supply. ln(18)/ln(100) is also around 0.63, so we will have a nice buffer for midgame.
+	win_rate = (1 - gene_history.loss_rate_);
 
-    //Cobb-Douglas Production exponents.  Can be normalized to sum to 1.
-    alpha_army_original = friendly_player_model.spending_model_.alpha_army = gene_history.a_army_out_mutate_; // army starved parameter.
-    alpha_econ_original = friendly_player_model.spending_model_.alpha_econ = gene_history.a_econ_out_mutate_; // econ starved parameter.
-    alpha_tech_original = friendly_player_model.spending_model_.alpha_tech = gene_history.a_tech_out_mutate_; // tech starved parameter.
-    adaptation_rate = gene_history.r_out_mutate_; //rate of worker growth.
+	//get initial build order.
+	buildorder.getInitialBuildOrder(gene_history.build_order_);
 
-    win_rate = (1 - gene_history.loss_rate_);
+	//update Map Grids
+	current_map_inventory.updateBuildablePos();
+	current_map_inventory.updateUnwalkable();
+	//inventory.updateSmoothPos();
+	current_map_inventory.updateMapVeins();
+	current_map_inventory.updateMapVeinsOut(Position(Broodwar->self()->getStartLocation()) + Position(UnitTypes::Zerg_Hatchery.dimensionLeft(), UnitTypes::Zerg_Hatchery.dimensionUp()), current_map_inventory.home_base_, current_map_inventory.map_out_from_home_);
+	//inventory.updateMapChokes();
+	current_map_inventory.updateBaseLoc(land_inventory);
+	current_map_inventory.getStartPositions();
 
-    //get initial build order.
-    buildorder.getInitialBuildOrder( gene_history.build_order_ );
-
-    //update Map Grids
-    current_map_inventory.updateBuildablePos();
-    current_map_inventory.updateUnwalkable();
-    //inventory.updateSmoothPos();
-    current_map_inventory.updateMapVeins();
-    current_map_inventory.updateMapVeinsOut( Position(Broodwar->self()->getStartLocation()) + Position(UnitTypes::Zerg_Hatchery.dimensionLeft(), UnitTypes::Zerg_Hatchery.dimensionUp()), current_map_inventory.home_base_, current_map_inventory.map_out_from_home_ );
-    //inventory.updateMapChokes();
-    current_map_inventory.updateBaseLoc( land_inventory );
-    current_map_inventory.getStartPositions();
-
-    //update timers.
-    short_delay = 0;
-    med_delay = 0;
-    long_delay = 0;
-    my_reservation = Reservation();
+	//update timers.
+	short_delay = 0;
+	med_delay = 0;
+	long_delay = 0;
+	my_reservation = Reservation();
 
 	enemy_player_model.readPlayerLog(enemy_player_model);
 
-    //friendly_player_model.setLockedOpeningValues();
+	//friendly_player_model.setLockedOpeningValues();
 
-    // Testing Build Order content intenstively.
-    ofstream output; // Prints to brood war file while in the WRITE file.
-    output.open(".\\bwapi-data\\write\\BuildOrderFailures.txt", ios_base::app);
-    string print_value = "";
-    print_value += gene_history.build_order_;
-    output << "Trying Build Order" << print_value << endl;
-    output.close();
+	// Testing Build Order content intenstively.
+	ofstream output; // Prints to brood war file while in the WRITE file.
+	output.open(".\\bwapi-data\\write\\BuildOrderFailures.txt", ios_base::app);
+	string print_value = "";
+	print_value += gene_history.build_order_;
+	output << "Trying Build Order" << print_value << endl;
+	output.close();
 
+
+// Setup cartridges and overwrite previous values for specific matchups
+	// Cartridges for Zerg vs Zerg
+	if (Broodwar->enemy()->getRace() == Races::Zerg) {
+		map<UnitType, int> unit_cart = { { UnitTypes::Zerg_Zergling , INT_MIN },{ UnitTypes::Zerg_Mutalisk, INT_MIN } };
+		map<UnitType, int> building_cart = { { UnitTypes::Zerg_Hatchery, INT_MIN } ,{ UnitTypes::Zerg_Lair, INT_MIN },{ UnitTypes::Zerg_Spawning_Pool, INT_MIN } ,{ UnitTypes::Zerg_Evolution_Chamber, INT_MIN },{ UnitTypes::Zerg_Spire, INT_MIN },{ UnitTypes::Zerg_Creep_Colony, INT_MIN },{ UnitTypes::Zerg_Sunken_Colony, INT_MIN },{ UnitTypes::Zerg_Spore_Colony, INT_MIN } };
+		map<UpgradeType, int> upgrade_cart = { { UpgradeTypes::Metabolic_Boost, INT_MIN },{ UpgradeTypes::Zerg_Flyer_Carapace, INT_MIN },{ UpgradeTypes::Zerg_Flyer_Attacks, INT_MIN } };
+		map<TechType, int> tech_cart = {};
+		friendly_player_model.setLockedOpeningValues(unit_cart, building_cart, upgrade_cart, tech_cart, gene_history.build_order_);
+	}
+
+	// Cartridge for if the enemy has no stealth detection (1h lurker rush with +2 sunkens)
+	if (friendly_player_model.maxStock[14] == 0) {
+		string build = "drone drone drone drone drone pool drone extract overlord creep drone ling ling ling sunken lair drone creep overlord drone hydra_den hydra hydra hydra hydra ling ling ling ling lurker_tech"; //1 h lurker, tenative. + 2 creep
+		map<UnitType, int> unit_cart = { { UnitTypes::Zerg_Zergling, INT_MIN }, { UnitTypes::Zerg_Hydralisk, INT_MIN }, { UnitTypes::Zerg_Lurker, INT_MIN }, { UnitTypes::Zerg_Lurker_Egg, INT_MIN } };
+		map<UnitType, int> building_cart = { { UnitTypes::Zerg_Hatchery, INT_MIN } ,{ UnitTypes::Zerg_Lair, INT_MIN },{ UnitTypes::Zerg_Spawning_Pool, INT_MIN } ,{ UnitTypes::Zerg_Evolution_Chamber, INT_MIN },{ UnitTypes::Zerg_Hydralisk_Den, INT_MIN },{ UnitTypes::Zerg_Creep_Colony, INT_MIN },{ UnitTypes::Zerg_Sunken_Colony, INT_MIN },{ UnitTypes::Zerg_Spore_Colony, INT_MIN } };
+		map<UpgradeType, int> upgrade_cart = { { UpgradeTypes::Metabolic_Boost, INT_MIN } };
+		map<TechType, int> tech_cart = { { TechTypes::Lurker_Aspect, INT_MIN } };
+		friendly_player_model.setLockedOpeningValues(unit_cart, building_cart, upgrade_cart, tech_cart, build);
+	}
+
+	// Cartridge for air-only opponents -- If they make flying units and their ground combat units = 0
+	if (friendly_player_model.maxStockAverage[0] > 0 && friendly_player_model.minStockAverage[1] == 0) {
+		string build = "drone drone drone drone overlord drone drone drone hatch pool extract drone drone drone ling drone drone lair overlord drone drone drone drone drone drone ling drone queens_nest spire drone creep drone drone overlord drone hive spore extract drone drone drone overlord drone drone drone drone hatch drone drone creep greater_spire drone drone drone overlord drone drone spore devourer devourer devourer devourer"; //3h - Devourers.
+		map<UnitType, int> unit_cart = { { UnitTypes::Zerg_Scourge, INT_MIN },{ UnitTypes::Zerg_Hydralisk, INT_MIN },{ UnitTypes::Zerg_Zergling , INT_MIN },{ UnitTypes::Zerg_Devourer, INT_MIN } };
+		map<UnitType, int> building_cart = { { UnitTypes::Zerg_Spawning_Pool, INT_MIN } ,{ UnitTypes::Zerg_Evolution_Chamber, INT_MIN },{ UnitTypes::Zerg_Hydralisk_Den, INT_MIN },{ UnitTypes::Zerg_Spire, INT_MIN },{ UnitTypes::Zerg_Queens_Nest , INT_MIN }, { UnitTypes::Zerg_Greater_Spire, INT_MIN },{ UnitTypes::Zerg_Hatchery, INT_MIN } ,{ UnitTypes::Zerg_Lair, INT_MIN },{ UnitTypes::Zerg_Hive, INT_MIN },{ UnitTypes::Zerg_Creep_Colony, INT_MIN }, { UnitTypes::Zerg_Spore_Colony, INT_MIN } };
+		map<UpgradeType, int> upgrade_cart = { { UpgradeTypes::Zerg_Flyer_Carapace, INT_MIN } ,{ UpgradeTypes::Zerg_Flyer_Attacks, INT_MIN },{ UpgradeTypes::Pneumatized_Carapace, INT_MIN } };
+		map<TechType, int> tech_cart = { };
+		friendly_player_model.setLockedOpeningValues(unit_cart, building_cart, upgrade_cart, tech_cart, build);
+	}
+
+	// Cartridge for opponents that can't shoot up -- If their stock shoot_up = 0 and their stock shoot_up_and_down = 0
+	if (friendly_player_model.minStockAverage[2] == 0 && friendly_player_model.minStockAverage[3] == 0) {
+		string build = "drone drone drone drone drone pool drone extract overlord creep drone ling ling ling sunken drone lair"; //1 base - 9 pool to fast spire w/o ling speed + 1 creep
+		map<UnitType, int> unit_cart = { { UnitTypes::Zerg_Zergling , INT_MIN },{ UnitTypes::Zerg_Mutalisk, INT_MIN } };
+		map<UnitType, int> building_cart = { { UnitTypes::Zerg_Hatchery, INT_MIN } ,{ UnitTypes::Zerg_Lair, INT_MIN },{ UnitTypes::Zerg_Spawning_Pool, INT_MIN } ,{ UnitTypes::Zerg_Evolution_Chamber, INT_MIN },{ UnitTypes::Zerg_Spire, INT_MIN },{ UnitTypes::Zerg_Creep_Colony, INT_MIN },{ UnitTypes::Zerg_Sunken_Colony, INT_MIN },{ UnitTypes::Zerg_Spore_Colony, INT_MIN } };
+		map<UpgradeType, int> upgrade_cart = { { UpgradeTypes::Zerg_Flyer_Carapace, INT_MIN },{ UpgradeTypes::Zerg_Flyer_Attacks, INT_MIN } };
+		map<TechType, int> tech_cart = {};
+	}
+
+	// Cartridge for regular rush opponents -- If they only ever have one base, their max tech stock is below 500, but we don't spot combat units until after 3 minutes
+	// Passes full cartridges only changes the build order
+	if (friendly_player_model.minStockAverage[23] == 0 && friendly_player_model.maxStock[27] < 500 && friendly_player_model.minTimeAverage[6] > 300) {
+		string build = "drone drone drone drone drone overlord drone drone drone pool creep drone sunken creep drone sunken creep drone sunken creep drone sunken evo drone creep drone sunken creep drone sunken"; //super sunken build
+		map<UnitType, int> unit_cart = { { UnitTypes::Zerg_Ultralisk, INT_MIN } ,{ UnitTypes::Zerg_Mutalisk, INT_MIN },{ UnitTypes::Zerg_Scourge, INT_MIN },{ UnitTypes::Zerg_Hydralisk, INT_MIN },{ UnitTypes::Zerg_Zergling , INT_MIN },{ UnitTypes::Zerg_Lurker, INT_MIN } ,{ UnitTypes::Zerg_Guardian, INT_MIN } ,{ UnitTypes::Zerg_Devourer, INT_MIN } };
+		map<UnitType, int> building_cart = { { UnitTypes::Zerg_Spawning_Pool, INT_MIN } ,{ UnitTypes::Zerg_Evolution_Chamber, INT_MIN },{ UnitTypes::Zerg_Hydralisk_Den, INT_MIN },{ UnitTypes::Zerg_Spire, INT_MIN },{ UnitTypes::Zerg_Queens_Nest , INT_MIN },{ UnitTypes::Zerg_Ultralisk_Cavern, INT_MIN } ,{ UnitTypes::Zerg_Greater_Spire, INT_MIN },{ UnitTypes::Zerg_Hatchery, INT_MIN } ,{ UnitTypes::Zerg_Lair, INT_MIN },{ UnitTypes::Zerg_Hive, INT_MIN },{ UnitTypes::Zerg_Creep_Colony, INT_MIN },{ UnitTypes::Zerg_Sunken_Colony, INT_MIN }, { UnitTypes::Zerg_Spore_Colony, INT_MIN } };
+		map<UpgradeType, int> upgrade_cart = { { UpgradeTypes::Zerg_Carapace, INT_MIN } ,{ UpgradeTypes::Zerg_Flyer_Carapace, INT_MIN },{ UpgradeTypes::Zerg_Melee_Attacks, INT_MIN },{ UpgradeTypes::Zerg_Missile_Attacks, INT_MIN },{ UpgradeTypes::Zerg_Flyer_Attacks, INT_MIN },{ UpgradeTypes::Antennae, INT_MIN },{ UpgradeTypes::Pneumatized_Carapace, INT_MIN },{ UpgradeTypes::Metabolic_Boost, INT_MIN },{ UpgradeTypes::Adrenal_Glands, INT_MIN },{ UpgradeTypes::Muscular_Augments, INT_MIN },{ UpgradeTypes::Grooved_Spines, INT_MIN },{ UpgradeTypes::Chitinous_Plating, INT_MIN },{ UpgradeTypes::Anabolic_Synthesis, INT_MIN } };
+		map<TechType, int> tech_cart = { { TechTypes::Lurker_Aspect, INT_MIN } };
+		friendly_player_model.setLockedOpeningValues(unit_cart, building_cart, upgrade_cart, tech_cart, build);
+	}
+
+	// Cartridge for super fast rush opoonents -- If they only ever have one base, their max tech stock is below 500, and we see combat units before 3 minutes
+	// Passes full cartridges only changes the build order
+	if (friendly_player_model.minStockAverage[23] == 0 && friendly_player_model.maxStock[27] < 500 && friendly_player_model.minTimeAverage[6] < 300) {
+		string build = "drone pool drone drone ling ling ling overlord ling ling ling ling ling ling ling ling"; // 5pool with some commitment.
+		map<UnitType, int> unit_cart = { { UnitTypes::Zerg_Ultralisk, INT_MIN } ,{ UnitTypes::Zerg_Mutalisk, INT_MIN },{ UnitTypes::Zerg_Scourge, INT_MIN },{ UnitTypes::Zerg_Hydralisk, INT_MIN },{ UnitTypes::Zerg_Zergling , INT_MIN },{ UnitTypes::Zerg_Lurker, INT_MIN } ,{ UnitTypes::Zerg_Guardian, INT_MIN } ,{ UnitTypes::Zerg_Devourer, INT_MIN } };
+		map<UnitType, int> building_cart = { { UnitTypes::Zerg_Spawning_Pool, INT_MIN } ,{ UnitTypes::Zerg_Evolution_Chamber, INT_MIN },{ UnitTypes::Zerg_Hydralisk_Den, INT_MIN },{ UnitTypes::Zerg_Spire, INT_MIN },{ UnitTypes::Zerg_Queens_Nest , INT_MIN },{ UnitTypes::Zerg_Ultralisk_Cavern, INT_MIN } ,{ UnitTypes::Zerg_Greater_Spire, INT_MIN },{ UnitTypes::Zerg_Hatchery, INT_MIN } ,{ UnitTypes::Zerg_Lair, INT_MIN },{ UnitTypes::Zerg_Hive, INT_MIN },{ UnitTypes::Zerg_Creep_Colony, INT_MIN },{ UnitTypes::Zerg_Sunken_Colony, INT_MIN }, { UnitTypes::Zerg_Spore_Colony, INT_MIN } };
+		map<UpgradeType, int> upgrade_cart = { { UpgradeTypes::Zerg_Carapace, INT_MIN } ,{ UpgradeTypes::Zerg_Flyer_Carapace, INT_MIN },{ UpgradeTypes::Zerg_Melee_Attacks, INT_MIN },{ UpgradeTypes::Zerg_Missile_Attacks, INT_MIN },{ UpgradeTypes::Zerg_Flyer_Attacks, INT_MIN },{ UpgradeTypes::Antennae, INT_MIN },{ UpgradeTypes::Pneumatized_Carapace, INT_MIN },{ UpgradeTypes::Metabolic_Boost, INT_MIN },{ UpgradeTypes::Adrenal_Glands, INT_MIN },{ UpgradeTypes::Muscular_Augments, INT_MIN },{ UpgradeTypes::Grooved_Spines, INT_MIN },{ UpgradeTypes::Chitinous_Plating, INT_MIN },{ UpgradeTypes::Anabolic_Synthesis, INT_MIN } };
+		map<TechType, int> tech_cart = { { TechTypes::Lurker_Aspect, INT_MIN } };
+	}
+
+	// Cartridge for worker rush opponents -- If they never build any combat units
+	// Passes full cartridges only changes the build order
+	if (friendly_player_model.maxStockAverage[6] == 0) {
+		string build = "drone pool drone drone ling ling ling overlord ling ling ling ling ling ling ling ling"; // 5pool with some commitment.
+		map<UnitType, int> unit_cart = { { UnitTypes::Zerg_Ultralisk, INT_MIN } ,{ UnitTypes::Zerg_Mutalisk, INT_MIN },{ UnitTypes::Zerg_Scourge, INT_MIN },{ UnitTypes::Zerg_Hydralisk, INT_MIN },{ UnitTypes::Zerg_Zergling , INT_MIN },{ UnitTypes::Zerg_Lurker, INT_MIN } ,{ UnitTypes::Zerg_Guardian, INT_MIN } ,{ UnitTypes::Zerg_Devourer, INT_MIN } };
+		map<UnitType, int> building_cart = { { UnitTypes::Zerg_Spawning_Pool, INT_MIN } ,{ UnitTypes::Zerg_Evolution_Chamber, INT_MIN },{ UnitTypes::Zerg_Hydralisk_Den, INT_MIN },{ UnitTypes::Zerg_Spire, INT_MIN },{ UnitTypes::Zerg_Queens_Nest , INT_MIN },{ UnitTypes::Zerg_Ultralisk_Cavern, INT_MIN } ,{ UnitTypes::Zerg_Greater_Spire, INT_MIN },{ UnitTypes::Zerg_Hatchery, INT_MIN } ,{ UnitTypes::Zerg_Lair, INT_MIN },{ UnitTypes::Zerg_Hive, INT_MIN },{ UnitTypes::Zerg_Creep_Colony, INT_MIN },{ UnitTypes::Zerg_Sunken_Colony, INT_MIN }, { UnitTypes::Zerg_Spore_Colony, INT_MIN } };
+		map<UpgradeType, int> upgrade_cart = { { UpgradeTypes::Zerg_Carapace, INT_MIN } ,{ UpgradeTypes::Zerg_Flyer_Carapace, INT_MIN },{ UpgradeTypes::Zerg_Melee_Attacks, INT_MIN },{ UpgradeTypes::Zerg_Missile_Attacks, INT_MIN },{ UpgradeTypes::Zerg_Flyer_Attacks, INT_MIN },{ UpgradeTypes::Antennae, INT_MIN },{ UpgradeTypes::Pneumatized_Carapace, INT_MIN },{ UpgradeTypes::Metabolic_Boost, INT_MIN },{ UpgradeTypes::Adrenal_Glands, INT_MIN },{ UpgradeTypes::Muscular_Augments, INT_MIN },{ UpgradeTypes::Grooved_Spines, INT_MIN },{ UpgradeTypes::Chitinous_Plating, INT_MIN },{ UpgradeTypes::Anabolic_Synthesis, INT_MIN } };
+		map<TechType, int> tech_cart = { { TechTypes::Lurker_Aspect, INT_MIN } };
+	}
 }
 
 void CUNYAIModule::onEnd( bool isWinner )
@@ -178,16 +246,16 @@ void CUNYAIModule::onEnd( bool isWinner )
         << ',' << buildorder.initial_building_gene_
         << endl;
     output.close();
-	enemy_player_model.writePlayerLog(enemy_player_model, true);
-	/*ifstream check(".\\bwapi-data\\write\\" + Broodwar->mapFileName() + Broodwar->enemy()->getName() + ".txt", ios_base::in);
-	if (!check)
-	{
-		ofstream detector;
-		detector.open(".\\bwapi-data\\write\\" + Broodwar->mapFileName() + Broodwar->enemy()->getName() + ".txt", ios_base::app);
-		detector << -1;
-		detector.close();
-	}
-	check.close();*/
+    enemy_player_model.writePlayerLog(enemy_player_model, true);
+    /*ifstream check(".\\bwapi-data\\write\\" + Broodwar->mapFileName() + Broodwar->enemy()->getName() + ".txt", ios_base::in);
+    if (!check)
+    {
+        ofstream detector;
+        detector.open(".\\bwapi-data\\write\\" + Broodwar->mapFileName() + Broodwar->enemy()->getName() + ".txt", ios_base::app);
+        detector << -1;
+        detector.close();
+    }
+    check.close();*/
     if constexpr (MOVE_OUTPUT_BACK_TO_READ) {
         rename(".\\bwapi-data\\write\\output.txt", ".\\bwapi-data\\read\\output.txt"); // Furthermore, rename will fail if there is already an existing file.
     }
@@ -284,7 +352,6 @@ void CUNYAIModule::onFrame()
 
     if ((starting_enemy_race == Races::Random || starting_enemy_race == Races::Unknown) && Broodwar->enemy()->getRace() != starting_enemy_race) {
         //Initialize model variables.
-
         GeneticHistory gene_history = GeneticHistory(".\\bwapi-data\\read\\output.txt", friendly_player_model);
 
         delta = gene_history.delta_out_mutate_; //gas starved parameter. Triggers state if: ln_gas/(ln_min + ln_gas) < delta;  Higher is more gas.
@@ -338,10 +405,8 @@ void CUNYAIModule::onFrame()
     land_inventory.updateMiners();
 
     // Update scouts, check if still alive.
-    scouting.updateScouts();
-    // If enemy has units that can shoot overlords, stop overlord scouting
-    if ( enemy_player_model.enemy_race_ == Races::Terran || (enemy_player_model.units_.stock_shoots_up_ || enemy_player_model.units_.stock_both_up_and_down_) )
-        scouting.let_overlords_scout_ = false;
+    scouting.updateScouts(enemy_player_model, friendly_player_model);
+
     // Disable scouting temporarily if we have a massive army to attack or are under threat of being killed
     bool disable_scouting = false; //(((friendly_player_model.units_.stock_fighting_total_ - Stock_Units(UnitTypes::Zerg_Sunken_Colony, friendly_player_model.units_) - Stock_Units(UnitTypes::Zerg_Spore_Colony, friendly_player_model.units_) > enemy_player_model.units_.stock_fighting_total_ * 3) ||
                             //(enemy_player_model.units_.stock_fighting_total_ > friendly_player_model.units_.stock_fighting_total_)) &&
@@ -681,12 +746,21 @@ void CUNYAIModule::onFrame()
             //Only morph one larva this frame.
             if (!attempted_morph_larva_this_frame && u_type == UnitTypes::Zerg_Larva )
             {
-                // Build appropriate units. Check for suppply block, rudimentary checks for enemy composition.
                 attempted_morph_larva_this_frame = true;
+
+                //Force build a zergling for scouting if we don't have one available
+                if (scouting.force_zergling_) {
+                    Check_N_Grow(UnitTypes::Zerg_Zergling, u, true);
+                    scouting.force_zergling_ = false;
+                    last_frame_of_unit_morph_command = t_game;
+                    continue;
+                }
+
+                // Build appropriate units. Check for suppply block, rudimentary checks for enemy composition.
                 if (Reactive_BuildFAP(u, current_map_inventory, friendly_player_model.units_, enemy_player_model.units_)) {
                     last_frame_of_unit_morph_command = t_game;
+                    continue;
                 }
-                continue;
             }
 
             // Only ONE morph this frame. Potential adverse conflict with previous  Reactive_Build calls.

--- a/Source/CUNYAIModule.h
+++ b/Source/CUNYAIModule.h
@@ -15,11 +15,11 @@
 
 constexpr bool RESIGN_MODE = false; // must be off for proper game close in SC-docker
 constexpr bool ANALYSIS_MODE = false; // Printing records, etc.
-constexpr bool DRAWING_MODE = false; // Visualizations, printing records, etc. Should seperate these.
+constexpr bool DRAWING_MODE = true; // Visualizations, printing records, etc. Should seperate these.
 constexpr bool MOVE_OUTPUT_BACK_TO_READ = false; // should be FALSE for sc-docker, TRUE for chaoslauncher at home & Training against base ai.
 constexpr bool SSCAIT_OR_DOCKER = true; // should be TRUE for SC-docker, TRUE for SSCAIT.
 constexpr bool LEARNING_MODE = true; //if we are exploring new positions or simply keeping existing ones.  Should almost always be on. If off, prevents both mutation and interbreeding of parents, they will only clone themselves.
-constexpr bool TIT_FOR_TAT_ENGAGED = true; // permits in game-tit-for-tat responses.  Consider disabling this for TEST_MODE.
+constexpr bool TIT_FOR_TAT_ENGAGED = false; // permits in game-tit-for-tat responses.  Consider disabling this for TEST_MODE.
 constexpr bool TEST_MODE = false; // Locks in a build order and defined paramaters. Consider disabling TIT_FOR_TAT.
 
 // Remember not to use "Broodwar" in any global class constructor!
@@ -46,7 +46,6 @@ public:
   virtual void onSaveGame(std::string gameName);
   virtual void onUnitComplete(BWAPI::Unit unit);
   // Everything below this line is safe to modify.
-
 
 // Status of AI
   static double gamma; // for supply levels.  Supply is an inhibition on growth rather than a resource to spend.  Cost of growth.

--- a/Source/PlayerModelManager.h
+++ b/Source/PlayerModelManager.h
@@ -45,8 +45,7 @@ struct Player_Model {
 
     void setLockedOpeningValuesLingRush();
     void setLockedOpeningValues(const map<UnitType, int>& unit_cart, const map<UnitType, int>& building_cart, const map<UpgradeType, int>& upgrade_cart, const map<TechType, int>& tech_cart,
-                                const string& build = "", const int& a_army = NULL, const int& a_econ = NULL, const int& a_tech = NULL, const int& delta = NULL, const int& gamma = NULL);
-
+                                const string& build = "", const double& a_army = NULL, const double& a_econ = NULL, const double& a_tech = NULL, const double& delta = NULL, const double& gamma = NULL, const double &r = NULL);
     vector< UnitType > unit_type_;
     vector< int > unit_count_;
     vector< int > unit_incomplete_;
@@ -60,29 +59,29 @@ struct Player_Model {
     map<UpgradeType, int> upgrade_cartridge_;
     map<TechType, int> tech_cartridge_;
 
-	void playerStock(Player_Model & enemy_player_model);
-	void readPlayerLog(Player_Model & enemy_player_model);
-	void writePlayerLog(Player_Model & enemy_player_model, bool gameComplete);
-	int playerData[29];
-	int oldData[29];
-	int oldIntel[29];
-	//new stuff
-	int minTime[29];
-	int minTimeAverage[29];
+    void playerStock(Player_Model & enemy_player_model);
+    void readPlayerLog(Player_Model & enemy_player_model);
+    void writePlayerLog(Player_Model & enemy_player_model, bool gameComplete);
+    int playerData[29];
+    int oldData[29];
+    int oldIntel[29];
+    //new stuff
+    int minTime[29];
+    int minTimeAverage[29];
 
-	int minStock[29];
-	int minStockAverage[29];
+    int minStock[29];
+    int minStockAverage[29];
 
-	int maxStock[29];
-	int maxStockAverage[29];
-
-
-	int maxTime[29];
-	int maxTimeAverage[29];
+    int maxStock[29];
+    int maxStockAverage[29];
 
 
-	int oldMinStock[29];
-	int oldMinTime[29];
-	int oldMaxStock[29];
-	int oldMaxTime[29];
+    int maxTime[29];
+    int maxTimeAverage[29];
+
+
+    int oldMinStock[29];
+    int oldMinTime[29];
+    int oldMaxStock[29];
+    int oldMaxTime[29];
 };

--- a/Source/ScoutingManager.h
+++ b/Source/ScoutingManager.h
@@ -14,6 +14,7 @@ struct ScoutingManager {
     bool exists_zergling_scout_;
     bool exists_expo_zergling_scout_;
     bool found_enemy_base_;
+    bool force_zergling_;
 
     Unit overlord_scout_;
     Unit zergling_scout_;
@@ -31,7 +32,7 @@ struct ScoutingManager {
 
     // Checks if unit is our scouting unit
     Position getScoutTargets(const Unit &unit, Map_Inventory &inv, Unit_Inventory &ei);
-    void updateScouts();
+    void updateScouts(const Player_Model& enemy_player_model, const Player_Model& friendly_player_model);
     bool needScout(const Unit &unit, const int &t_game) const;
     void setScout(const Unit &unit, const int &ling_type=0);
     void clearScout(const Unit &unit);


### PR DESCRIPTION
* ScoutingManager v0.1

Bare-bones scouting manager, not ready for production

- Sets, clears, and updates zergling/overlord scouts

-Shouldn't overlord scout against terran
-Currently only scouts initial base locations
-Has some problems updating scouts

* Should have been included in last commit

Forgot to change an inventory to map_inventory

* ScoutingManager v0.11

Initial overlord scout is functional again (except against Terran)
Some stylistic changes
Few more things that should have been included in v0.1

* ScoutingManager v.9

-- Scouting manager now has a suicide ling scout and an expo ling scout which checks random expansions on map all game
-- Overlords should stop scouting once the enemy has units that can kill it (not fully tested)
-- Map_Inventory::MeanEnemyBuildingLocation (ignores Resource depots and Refineries)
-- Added functionality to Scouting getScoutTargets
-- Cleaned up Scouting needScout
-- Fixed Scouting updateScouts (checks for nullpointers prior now)

* ScoutingManager v9.1

-- Scouting now gets disabled when we are under threat of losing or if our army greatly outnumbers the enemy.
-- Enemy base scout now runs to the nearest mean enemy building instead of just the mean position

* ScoutingManager v.92

-- Added scout phase_ in Draw Mode for scouting units
-- Added Scouting boolean to drawTextScreen in Draw Mode
-- Readded the Game Seed to drawTextScreen in Draw Mode

* ScoutingManager v1

-- Expo ling scouts now only scout the bases closer to the enemy location. Not a fantastic implementation but was having difficulties implementing with weighted probabilities

* ScoutingManager v1.0

Potential Exception Error? Just in case

* ScoutingManager v1.01

-- Syntactic changes
-- Made a function in the Player Model to handle all the starting game conditions
-- Moved the disablement of overlord scouting against Terran to the gameStartConditions function in the Player Model

* ScoutingManager v1.01a

-- Should have been included in v1.01

* Revert gameStartConditions playerModelManager

The changes weren't working as intended and causing crashes. Reverting for now, will try to get it to work and recommit later

* ScoutingManager v1.02

-- Put in the fix for the "fall through" if-statements in the getScoutTargets function that was causing freezing
-- Untabified all my edits/changes to keep project consistency

* ScoutingManager v1.03

Added enemy_race_ variable to the player model. Based letting overlord scouts on that variable.

* ScoutingManager v1.03a

Forgot to remove diagnostic text

* ScoutingManager v1.1

-- Replaced the getScoutTargets expo ling vectors with a map of <int(base_distance), Position>
-- Complete overhaul of the getScoutTargets expo-ling logic, ScoutingManager.cpp: lines 65-114. Working okay, but not flawlessly (using the mean of radial distances is kind of wonky)
-- To avoid any confusion, a scout unit's phase_ now get's set to "None" when the scout is cleared.
-- Added a diagnostic line for scouts in DRAW_MODE (suicide zergling and overlords are purple, expo lings are yellow)
-- Moved the let_overlords_scout bool check out of the "for every unit" loop.
-- Scouting is now always enabled by default.
-- Added the clock timer to the scouting module
-- Overlord and expo ling scouts now get reassigned a new scouting location instead of being cleared. Suicide ling scouts still get cleared (has some benefits early game).

* ScoutingManager v1.11

-- Added expo_positions_complete to the Map_Inventory
-- The scouting expo-ling now avoids the enemy main base and all starting positions, mostly

* Positional adjustments for draw screen

Moved the positions of some of the draw interfaces to make room for Scouting

* Revert "Positional adjustments for draw screen"

This reverts commit a1579af093ee53d28287adba7c92aba270209135.

* Positional adjustments for draw screen

Moved the positions of some of the draw interfaces to make room for Scouting

* Devourer build

-- Added assemblymanager functionality for Hive, Greater Spire, Queen's Nest, and Devourers
-- Placed the devourer build into the assemblymanager build orders. Warning: it will be a guarenteed loss against anything other than an air-tech rush.

* Race specific build orders

-- Each race now has it's own set of build orders to pick from
-- Added some creeps and sunkens to the build orders for testing

* Build order optimizations / Creep colony fix

-- Optimized the creep/sunken timings for all the "+ sunken" build orders
-- Added a check in the AssemblyManager creep colony logic to make sure that the eligible spots to build a creep colony actually have enough creep available to build upon.
-- Removed most ZvZ builds as they all go down the same tech path (mutas) anyway and could be encompassed by a cartridge instead

* Generic LockedOpeningValues method

-- Added a generic method that takes parameters/cartridges and locks them in (there is currently something wrong with passing builds but it's not really needed yet)
-- Added the first cartridge for the ZvZ matchup to the genetic history manager

* Scouting changes

-- Overlord scouting now is reenabled if we have researched overlord speed
-- Refactored the overlord scouting code. Condensed the disable overlord scouting if Terran or if enemy has stuff that can kill it into the updateScouts() in ScoutingManager.
-- Overlord scouts now attempt to scout every 30 seconds rather than 60. Seems a like a net positive change now that we scout with overlord speed.

* Force build a scouting zergling

-- Now will force build a scouting zergling if one is not available on the map (even if zerglings are not in the cartridge)
-- Changed the setLocked() functions parameters to doubles from ints (phew)
-- Untabified everything to maintain style

* Revert "Merge remote-tracking branch 'upstream/Student_Work'"

This reverts commit 34877d016f0774a1ec940572646c1302b9c584ed, reversing
changes made to 4d47a312d2294b6ff1d3538af7cc9c30e68c5143.

* Clear build order when new build is passed in

-- Build order now gets cleared when initialized. Prevents an overwritten build order from being appended instead of being a new seperate build order

* Situational Catridges

-- Moved cartridges from GeneticHistoryManager to onStart() in CUNYAIModule
-- Added cartridges for specific situations: no stealth detection, air-only, opponents that can't shoot air, rushes, super-fast rushes, and worker rushes

* Cartridiges else if -> if

-- Changed the else-if statements for the cartridiges to if statements. If statements were what was intended.

* Revert "Revert "Merge remote-tracking branch 'upstream/Student_Work'""

This reverts commit 198395a61b54cde742a08bea7c2d127f9e55f0e5.